### PR TITLE
Fix: append clears placer instead of overwriting the Fill Cave slot

### DIFF
--- a/src/main/java/com/github/argon/sos/planttree/util/JobUtil.java
+++ b/src/main/java/com/github/argon/sos/planttree/util/JobUtil.java
@@ -3,15 +3,50 @@ package com.github.argon.sos.planttree.util;
 import com.github.argon.sos.planttree.log.Logger;
 import com.github.argon.sos.planttree.log.Loggers;
 import settlement.job.Job;
+import settlement.job.JobClears;
 import settlement.main.SETT;
+import view.tool.PLACABLE;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
 
 public class JobUtil {
     private final static Logger log = Loggers.getLogger(JobUtil.class);
 
+    /**
+     * Appends a job's placer to the settlement "clears" menu tool list.
+     *
+     * <p>The last slot holds a live vanilla placer (caveFill), and {@link JobClears#placers}
+     * is shared by reference with {@code JOBS.clears}, so we grow-and-append rather than
+     * overwrite. The field is {@code final}, hence the reflective set.</p>
+     */
     public static void addClearsJob(Job job) {
-        int pos = SETT.JOBS().clearss.placers.length - 1;
-        SETT.JOBS().clearss.placers[pos] = job.placer();
+        JobClears clears = SETT.JOBS().clearss;
+        PLACABLE placer = job.placer();
+        PLACABLE[] current = clears.placers;
 
-        log.debug("Added job class '%s' to clears jobs", job.getClass().getSimpleName());
+        // addOnInit re-runs on save reload; skip if already appended to avoid unbounded growth.
+        Class<?> placerType = placer.getClass();
+        for (PLACABLE existing : current) {
+            if (existing != null && existing.getClass() == placerType) {
+                log.debug("Clears placer '%s' already registered, skipping", placerType.getSimpleName());
+                return;
+            }
+        }
+
+        PLACABLE[] grown = Arrays.copyOf(current, current.length + 1);
+        grown[current.length] = placer;
+
+        try {
+            Field field = JobClears.class.getDeclaredField("placers");
+            field.setAccessible(true);
+            field.set(clears, grown);
+        } catch (ReflectiveOperationException e) {
+            log.error("Failed to append clears placer for '%s'", job.getClass().getSimpleName(), e);
+            return;
+        }
+
+        log.debug("Appended '%s' to clears placers (size %d -> %d)",
+                job.getClass().getSimpleName(), current.length, grown.length);
     }
 }


### PR DESCRIPTION
## Problem

With the mod active, most non-house buildings can no longer be placed under mountains (only houses can). Verified in-game on **V71.31**.

## Root cause

`JobUtil.addClearsJob` registered the mod's tool by **overwriting the last slot** of the clears placer array:

```java
int pos = SETT.JOBS().clearss.placers.length - 1;   // = 6 on V71.31
SETT.JOBS().clearss.placers[pos] = job.placer();
```

On V70+ that last slot is `caveFill.placer()` (the "Fill Cave" tool). Crucially, `JobClears.placers` is shared **by reference** with `JOBS.clears` (`new ArrayList<>(clearss.placers)` wraps the array, it does not copy it), so the in-place write destroys the vanilla `caveFill` placer reference everywhere it's reachable — which is what breaks placing non-house buildings under mountains.

The tool still *appeared* in the menu only because overwriting `caveFill`'s slot made it no longer match the entry `BuildMain` skips.

## Fix

Grow the array by one and **append** the mod's placer, swapping the `final` `placers` field via reflection so every vanilla placer stays intact. A type-based guard prevents re-appending (and unbounded growth) when `addOnInit` re-runs on save reload.

## Verification

- Compiles against `SongsOfSyx.jar` V71.31 (JDK 21, `mvn validate` + `mvn package`).
- In-game: clears menu shows all vanilla tools **plus** Plant Tree, no duplicate.
- In-game: non-house buildings can be placed under mountains again.